### PR TITLE
test data is split into test and val

### DIFF
--- a/configs/claim_target_identification.jsonnet
+++ b/configs/claim_target_identification.jsonnet
@@ -15,7 +15,7 @@
       },
     },
   "train_data_path": 'Data/train.txt',
-  "test_data_path": 'Data/test.txt',
+  "test_data_path": 'Data/val.txt',
   "model": {
     "type": "crf_tagger",
     "label_encoding": "BIOUL",


### PR DESCRIPTION
Following changes are made to `create_dataset.py` file :
1. Doc string added
2. test data is divided into `test` and `val`. Now `test` contains 977 instance and `val` contains 300 instances.

Location of val datafile is updated in AllenNLP config