### PR TITLE
Adding wandb

### DIFF
--- a/configs/claim_target_identification.jsonnet
+++ b/configs/claim_target_identification.jsonnet
@@ -45,7 +45,7 @@
     },
   },
   "data_loader": {
-    //"batch_size": 64
+    "shuffle": true,
     "batch_size": 8
   },
   "trainer": {
@@ -53,13 +53,17 @@
         "type": "adam",
         "lr": 0.005
     },
-    //"checkpointer": {
-     //   "num_serialized_models_to_keep": 1,
-   // },
-    "validation_metric": "+span/overall/f1",
+    "validation_metric": "+accuracy",
     "num_epochs": 10,
     "grad_norm": 7.0,
     "patience": 5,
-
+"callbacks": [
+        {
+        "type": "custom_wandb",
+         'entity': std.extVar('WANDB_ENTITY'),
+         'project': std.extVar('WANDB_PROJECT'),
+         'files_to_save': ["config.json", "out.log","metrics.json"]
+         },
+         ],
   }
 }

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@
 import logging
 
 from allennlp import commands
+import wandb
 
 logger = logging.getLogger(__name__)
-
+wandb.init(project="test-project", entity="stcl")
 commands.main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+from tools.wandb_callback import WandBCallback

--- a/tools/wandb_callback.py
+++ b/tools/wandb_callback.py
@@ -1,0 +1,20 @@
+from typing import Dict, Any
+
+from allennlp.training.callbacks.wandb import WandBCallback
+from overrides import overrides
+from allennlp.training.callbacks.callback import TrainerCallback
+
+@TrainerCallback.register("custom_wandb")
+class CustomWandBCallback(WandBCallback):
+    @overrides
+    def on_end(
+            self,
+            trainer: "GradientDescentTrainer",
+            metrics: Dict[str, Any] = None,
+            epoch: int = None,
+            is_primary: bool = True,
+            **kwargs,
+    ) -> None:
+        self.wandb.log(metrics)
+        if is_primary:
+            self.close()


### PR DESCRIPTION
[W&B](https://wandb.ai/site) is experiment tracking platform for ML projects. It is compatible with AllenNLP as well, so we  use modified version of [Wandb callback](https://docs.allennlp.org/main/api/training/callbacks/wandb/) provided by AllenNLP.
wandb_callback.py is added. It logs metrics generated by AllenNLP training to W&B dashboard.

We also add this as `trainer.callbacks` in allennlp config.