### PR TITLE
not required, will use env variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,6 @@
 import logging
 
 from allennlp import commands
-import wandb
 
 logger = logging.getLogger(__name__)
-wandb.init(project="test-project", entity="stcl")
 commands.main()


### PR DESCRIPTION
We can specify W&B project name and entity name as environment variables when we execute training script.

```
WANDB_ENTITY=stcl,WANDB_PROJECT=test_project,WANDB_API_KEY=YOUR_API_KEY python main.py train -s experiments -f configs/claim_target_identification.jsonnet
```

WANDB_API_KEY can be found [here](https://wandb.ai/authorize) if logged in.