### PR TITLE
Initial setup for Sentiment Classification towards topic task

### DIFF
--- a/configs/claim_sentiment_classification.jsonnet
+++ b/configs/claim_sentiment_classification.jsonnet
@@ -1,0 +1,68 @@
+
+{
+  local transformer_model = "distilbert-base-uncased-finetuned-sst-2-english",
+  local transformer_max_length = 512,
+  local transformer_hidden_size = 768,
+  "dataset_reader": {
+    "type": "sent_data_reader",
+    "tokenizer": {
+    "type": "pretrained_transformer",
+    "model_name": transformer_model,
+    "add_special_tokens": false
+  },
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer",
+        "model_name": transformer_model,
+        "max_length": transformer_max_length
+      },
+      },
+    },
+  "train_data_path": 'Data/sentiment_train.txt',
+  "validation_data_path": 'Data/sentiment_val.txt',
+  "model": {
+    "type": "basic_classifier",
+    "dropout": 0.5,
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+            "type": "pretrained_transformer",
+            "model_name": transformer_model,
+            "max_length": transformer_max_length,
+            "train_parameters": false
+        },
+       },
+    },
+    "seq2vec_encoder": {
+        "type": "lstm",
+        "input_size": transformer_hidden_size,
+        "hidden_size": 300,
+        "num_layers": 2,
+        "dropout": 0.4394,
+        "bidirectional": true
+    },
+  },
+  "data_loader": {
+    "shuffle": true,
+    "batch_size": 8
+  },
+  "trainer": {
+    "optimizer": {
+        "type": "adam",
+        "lr": 0.00001,
+    },
+    "validation_metric": "+accuracy",
+    "num_epochs": 10,
+    "grad_norm": 7.0,
+    "patience": 5,
+"callbacks": [
+        {
+        "type": "custom_wandb",
+         'entity': std.extVar('WANDB_ENTITY'),
+         'project': std.extVar('WANDB_PROJECT'),
+         'files_to_save': ["config.json", "out.log","metrics.json"],
+         //'serialization_dir': 'experiment/wandb'
+         },
+         ],
+  }
+}

--- a/hpt/configs/sweep_claim_sentiment.yaml
+++ b/hpt/configs/sweep_claim_sentiment.yaml
@@ -1,0 +1,46 @@
+program: sweep_train.py
+method: random
+command:
+  - ${env}
+  - ${interpreter}
+  - ${program}
+  - "train"
+  - "-f"
+  - "configs/claim_sentiment_classification.jsonnet"
+  - "-s"
+  - "experiment/sentiment/hpt_trial/distilbert_base"
+  - "--include-package"
+  - "readers.SentDataReader"
+  - ${args}
+
+metric:
+  name: validation_accuracy
+  goal: maximize
+parameters:
+
+  trainer.optimizer.lr:
+    values: [0.1, 0.05,0.03,0.01,0.005,0.003,0.001,0.0005,0.0003,0.0001,0.00003,0.00001,0.000003,0.000001]
+  model.dropout:
+    distribution: uniform
+    min: 0.2
+    max: 0.8
+  model.seq2vec_encoder.dropout:
+    distribution: uniform
+    min: 0.2
+    max: 0.8
+  trainer.grad_norm:
+    distribution: uniform
+    min: 1
+    max: 10
+  trainer.patience:
+    min: 3
+    max: 10
+  trainer.num_epochs:
+    min: 4
+    max: 30
+  model.seq2vec_encoder.num_layers:
+    min: 1
+    max: 6
+  model.seq2vec_encoder.hidden_size:
+    min: 64
+    max: 512

--- a/readers/SentDataReader.py
+++ b/readers/SentDataReader.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Dict, Optional
+
+from allennlp.common.file_utils import cached_path
+from allennlp.data import Tokenizer
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.fields import LabelField, TextField, Field
+from allennlp.data.instance import Instance
+from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
+
+logger = logging.getLogger(__name__)
+
+
+@DatasetReader.register("sent_data_reader")
+class SentimentDatasetReader(DatasetReader):
+    """
+
+    # Parameters
+
+    token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
+        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+    """
+
+    def __init__(
+        self,
+        token_indexers: Dict[str, TokenIndexer] = None,
+        tokenizer: Optional[Tokenizer] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._tokenizer = tokenizer
+
+    def _read(self, file_path):
+        with open(cached_path(file_path), "r") as data_file:
+            logger.info("Reading instances from lines in file at: %s", file_path)
+            for line in data_file.readlines():
+                line = line.strip('\n')
+                if not line:
+                    continue
+
+                sentence, sentiment = line.split('###')
+                instance = self.text_to_instance(sentence, sentiment)
+                if instance is not None:
+                    yield instance
+
+    def text_to_instance(self, sentence: str, sentiment: int = None) -> Optional[Instance]:
+
+
+        tokens = self._tokenizer.tokenize(sentence)
+        text_field = TextField(tokens)
+        fields: Dict[str, Field] = {"tokens": text_field}
+
+        if sentiment is not None:
+            sentiment = '0' if sentiment == '-1' else '1'
+            fields["label"] = LabelField(sentiment)
+        return Instance(fields)
+
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["tokens"].token_indexers = self._token_indexers

--- a/readers/__init__.py
+++ b/readers/__init__.py
@@ -1,0 +1,1 @@
+import readers.SentDataReader


### PR DESCRIPTION
Following changes were made:
1. `create_dataset.py` can now create dataset for sentiment analysis task as well.
```python
python create_dataset.py
--output_dataset Data
--dataset_type 1
```
`dataset_type` parameter specifies kind of data to create from [original corpus](https://research.ibm.com/haifa/dept/vst/files/IBM_Debater_(R)_CS_EACL-2017.v1.zip)
**NOTE**: You must have Data folder in root directory of project for this command to run successfully. (We need to fix this later such that there is no need for Data folder to be present prior to execution of this command)

2. We created a custom dataset reader for our sentiment task called `SentimentDatasetReader` which reads data in the format that we create. For instance
```
Wind energy is a clean energy source###1
```

3. allennlp config for this task added. We use our custom dataset reader. We use [basic_classifier](http://docs.allennlp.org/v0.9.0/api/allennlp.models.basic_classifier.html) from AllenNLP as our model. We use pre-trained transformer embeddings from [DistilBERT](https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english) available at HuggingFace. Model can be trained using following command

```python
allennlp
train
-s experiment/sentiment
-f configs/claim_sentiment_classification.jsonnet
--include-package readers.SentDataReader
```

4. Finally, we create a sweep config for this task as well which will be used for tuning hyper parameters.