### PR TITLE
Predictions for each task is implemented

### DIFF
--- a/.allennlp_plugins
+++ b/.allennlp_plugins
@@ -1,0 +1,2 @@
+modules
+modules.commands.predict_target

--- a/README.md
+++ b/README.md
@@ -79,3 +79,33 @@ experiment/sentiment/absa
 Data/sentiment_test.txt
 ```
 
+### Prediction
+
+
+1. Claim Target Identification
+```
+allennlp \
+predict-stance
+--cuda-device 0 \
+--batch-size 8 \
+--output-file experiment/prediction/target/prediction.txt \
+--use-dataset-reader \
+--silent \
+experiment/target/bert_base_uncased \
+_@test
+```
+
+2. Claim Sentiment Classification
+
+```
+allennlp \
+predict-stance
+--cuda-device 0 \
+--batch-size 8 \
+--output-file experiment/prediction/sentiment/prediction.txt \
+--use-dataset-reader \
+--silent \
+experiment/sentiment/absa \
+_@test
+```
+

--- a/configs/claim_sentiment_classification_absa.jsonnet
+++ b/configs/claim_sentiment_classification_absa.jsonnet
@@ -4,7 +4,8 @@
   local transformer_max_length = 512,
   local transformer_hidden_size = 768,
   "dataset_reader": {
-    "type": "sent_data_reader2",
+    "type": "stance_data_reader",
+    "task": 2,
     "tokenizer": {
     "type": "pretrained_transformer",
     "model_name": transformer_model,
@@ -18,8 +19,8 @@
       },
       },
     },
-  "train_data_path": 'Data/sentiment_train.txt',
-  "validation_data_path": 'Data/sentiment_val.txt',
+  "train_data_path": 'Data/sentiment_train.txt@train',
+  "validation_data_path": 'Data/sentiment_val.txt@val',
   "model": {
    "type": "bert_for_classification",
     "dropout": 0.5,

--- a/configs/claim_sentiment_classification_absa.jsonnet
+++ b/configs/claim_sentiment_classification_absa.jsonnet
@@ -19,8 +19,8 @@
       },
       },
     },
-  "train_data_path": 'Data/sentiment_train.txt@train',
-  "validation_data_path": 'Data/sentiment_val.txt@val',
+  "train_data_path": '_@train',
+  "validation_data_path": '_@val',
   "model": {
    "type": "bert_for_classification",
     "dropout": 0.5,

--- a/configs/claim_target_identification_bert_base_uncased.jsonnet
+++ b/configs/claim_target_identification_bert_base_uncased.jsonnet
@@ -20,8 +20,8 @@
       },
       },
     },
-  "train_data_path": 'Data/train.txt@train',
-  "validation_data_path": 'Data/val.txt@val',
+  "train_data_path": '_@train',
+  "validation_data_path": '_@val',
   "model": {
     "type": "crf_tagger",
     "label_encoding": "BIOUL",

--- a/configs/claim_target_identification_bert_base_uncased.jsonnet
+++ b/configs/claim_target_identification_bert_base_uncased.jsonnet
@@ -5,7 +5,13 @@
   //local transformer_max_length = 128,
   local transformer_hidden_size = 768,
   "dataset_reader": {
-    "type": "sequence_tagging",
+    "type": "stance_data_reader",
+    "task":1,
+    "tokenizer": {
+    "type": "pretrained_transformer",
+    "model_name": transformer_model,
+    "add_special_tokens": false
+  },
     "token_indexers": {
       "tokens": {
         "type": "pretrained_transformer",
@@ -14,8 +20,8 @@
       },
       },
     },
-  "train_data_path": 'Data/train.txt',
-  "validation_data_path": 'Data/val.txt',
+  "train_data_path": 'Data/train.txt@train',
+  "validation_data_path": 'Data/val.txt@val',
   "model": {
     "type": "crf_tagger",
     "label_encoding": "BIOUL",

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -2,3 +2,4 @@ import modules.models
 import modules.utils
 import modules.hpt
 import modules.readers
+import modules.tools

--- a/modules/commands/predict.py
+++ b/modules/commands/predict.py
@@ -22,7 +22,7 @@ from allennlp.predictors.predictor import Predictor, JsonDict
 from allennlp.data import Instance
 
 
-@Subcommand.register("predict-target")
+@Subcommand.register("predict-stance")
 class PredictTarget(Predict):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/modules/commands/predict.py
+++ b/modules/commands/predict.py
@@ -1,0 +1,200 @@
+"""
+The `predict` subcommand allows you to make bulk JSON-to-JSON
+or dataset to JSON predictions using a trained model and its
+[`Predictor`](../predictors/predictor.md#predictor) wrapper.
+"""
+from typing import List, Iterator, Optional
+import argparse
+import sys
+import json
+
+from allennlp.commands import Predict
+from overrides import overrides
+
+from allennlp.commands.subcommand import Subcommand
+from allennlp.common import logging as common_logging
+from allennlp.common.checks import check_for_gpu, ConfigurationError
+from allennlp.common.file_utils import cached_path
+from allennlp.common.util import lazy_groups_of
+from allennlp.data.dataset_readers import MultiTaskDatasetReader
+from allennlp.models.archival import load_archive
+from allennlp.predictors.predictor import Predictor, JsonDict
+from allennlp.data import Instance
+
+
+@Subcommand.register("predict-target")
+class PredictTarget(Predict):
+    @overrides
+    def add_subparser(self, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
+        subparser = super().add_subparser(parser)
+
+        subparser.set_defaults(func=_predict)
+
+        return subparser
+
+
+def _get_predictor(args: argparse.Namespace) -> Predictor:
+    check_for_gpu(args.cuda_device)
+    archive = load_archive(
+        args.archive_file,
+        weights_file=args.weights_file,
+        cuda_device=args.cuda_device,
+        overrides=args.overrides,
+    )
+
+    predictor_args = args.predictor_args.strip()
+    if len(predictor_args) <= 0:
+        predictor_args = {}
+    else:
+        import json
+
+        predictor_args = json.loads(predictor_args)
+
+    return Predictor.from_archive(
+        archive,
+        args.predictor,
+        dataset_reader_to_load=args.dataset_reader_choice,
+        extra_args=predictor_args,
+    )
+
+
+class _PredictManager:
+    def __init__(
+        self,
+        predictor: Predictor,
+        input_file: str,
+        output_file: Optional[str],
+        batch_size: int,
+        print_to_console: bool,
+        has_dataset_reader: bool,
+        multitask_head: Optional[str] = None,
+    ) -> None:
+        self._predictor = predictor
+        self._input_file = input_file
+        self._output_file = None if output_file is None else open(output_file, "w")
+        self._batch_size = batch_size
+        self._print_to_console = print_to_console
+        self._dataset_reader = None if not has_dataset_reader else predictor._dataset_reader
+
+        self._multitask_head = multitask_head
+        if self._multitask_head is not None:
+            if self._dataset_reader is None:
+                raise ConfigurationError(
+                    "You must use a dataset reader when using --multitask-head."
+                )
+            if not isinstance(self._dataset_reader, MultiTaskDatasetReader):
+                raise ConfigurationError(
+                    "--multitask-head only works with a multitask dataset reader."
+                )
+        if (
+            isinstance(self._dataset_reader, MultiTaskDatasetReader)
+            and self._multitask_head is None
+        ):
+            raise ConfigurationError(
+                "You must specify --multitask-head when using a multitask dataset reader."
+            )
+
+    def _predict_json(self, batch_data: List[JsonDict]) -> Iterator[str]:
+        if len(batch_data) == 1:
+            results = [self._predictor.predict_json(batch_data[0])]
+        else:
+            results = self._predictor.predict_batch_json(batch_data)
+        for output in results:
+            yield self._predictor.dump_line(output)
+
+    def _predict_instances(self, batch_data: List[Instance]) -> Iterator[str]:
+        if len(batch_data) == 1:
+            results = [self._predictor.predict_instance(batch_data[0])]
+        else:
+            results = self._predictor.predict_batch_instance(batch_data)
+        for output in results:
+            if self._dataset_reader._task == 2:
+                claim, target, _ = ' '.join(output['tokens']).split('[SEP]')
+                claim = claim.split('[CLS]')[1].strip()
+                target = target.strip()
+                line = claim + '###' + target + '###' + output['label']
+            if self._dataset_reader._task == 1:
+                line = ' '.join(output['words'])+'###'+\
+                       ' '.join([ word for word, tag in zip(output['words'],output['tags']) if tag=='1'])
+            yield self._predictor.dump_line(line)
+
+    def _maybe_print_to_console_and_file(
+        self, index: int, prediction: str, model_input: str = None, sentiment: str =None
+    ) -> None:
+        if self._print_to_console:
+            if model_input is not None:
+                print(f"input {index}: ", model_input)
+            print("prediction: ", prediction)
+        if self._output_file is not None:
+            prediction = prediction.strip('\n').strip('"') + '###' + '1'+'\n'
+            self._output_file.write(prediction)
+
+    def _get_json_data(self) -> Iterator[JsonDict]:
+        if self._input_file == "-":
+            for line in sys.stdin:
+                if not line.isspace():
+                    yield self._predictor.load_line(line)
+        else:
+            input_file = cached_path(self._input_file)
+            with open(input_file, "r") as file_input:
+                for line in file_input:
+                    if not line.isspace():
+                        yield self._predictor.load_line(line)
+
+    def _get_instance_data(self) -> Iterator[Instance]:
+        if self._input_file == "-":
+            raise ConfigurationError("stdin is not an option when using a DatasetReader.")
+        elif self._dataset_reader is None:
+            raise ConfigurationError("To generate instances directly, pass a DatasetReader.")
+        else:
+            if isinstance(self._dataset_reader, MultiTaskDatasetReader):
+                assert (
+                    self._multitask_head is not None
+                )  # This is properly checked by the constructor.
+                yield from self._dataset_reader.read(
+                    self._input_file, force_task=self._multitask_head
+                )
+            else:
+                yield from self._dataset_reader.read(self._input_file)
+
+    def run(self) -> None:
+        has_reader = self._dataset_reader is not None
+        index = 0
+        if has_reader:
+            for batch in lazy_groups_of(self._get_instance_data(), self._batch_size):
+                for model_input_instance, result in zip(batch, self._predict_instances(batch)):
+                    self._maybe_print_to_console_and_file(index, result, str(model_input_instance),
+                                                          model_input_instance['sentiment'].label)
+                    index = index + 1
+        else:
+            for batch_json in lazy_groups_of(self._get_json_data(), self._batch_size):
+                for model_input_json, result in zip(batch_json, self._predict_json(batch_json)):
+                    self._maybe_print_to_console_and_file(
+                        index, result, json.dumps(model_input_json)
+                    )
+                    index = index + 1
+
+        if self._output_file is not None:
+            self._output_file.close()
+
+
+def _predict(args: argparse.Namespace) -> None:
+    common_logging.FILE_FRIENDLY_LOGGING = args.file_friendly_logging
+
+    predictor = _get_predictor(args)
+
+    if args.silent and not args.output_file:
+        print("--silent specified without --output-file.")
+        print("Exiting early because no output will be created.")
+        sys.exit(0)
+
+    manager = _PredictManager(
+        predictor,
+        args.input_file,
+        args.output_file,
+        args.batch_size,
+        not args.silent,
+        args.use_dataset_reader,
+        args.multitask_head,
+    )
+    manager.run()

--- a/modules/models/bert_for_classification.py
+++ b/modules/models/bert_for_classification.py
@@ -24,7 +24,7 @@ class BertForClassification(Model):
         dropout: float = None,
         num_labels: int = None,
         label_namespace: str = "labels",
-        namespace: str = "tokens",
+        namespace: str = "tags",
         initializer: InitializerApplicator = InitializerApplicator(),
         **kwargs,
     ) -> None:
@@ -51,7 +51,7 @@ class BertForClassification(Model):
     def forward(  # type: ignore
         self,
         tokens: TextFieldTensors,
-        label: torch.IntTensor = None,
+        sentiment: torch.IntTensor = None,
         metadata: MetadataField = None,
     ) -> Dict[str, torch.Tensor]:
 
@@ -80,7 +80,7 @@ class BertForClassification(Model):
         attention_mask=tokens['tokens']['mask'],
         token_type_ids=tokens['tokens']['type_ids'],
         position_ids=tokens['tokens']['segment_concat_mask'].int(),
-        labels = label)
+        labels = sentiment)
 
         logits = results.logits
         probs = torch.nn.functional.softmax(logits, dim=-1)
@@ -88,11 +88,11 @@ class BertForClassification(Model):
 
         output_dict = {"logits": logits, "probs": probs}
         output_dict["token_ids"] = util.get_token_ids_from_text_field_tensors(tokens)
-        if label is not None:
+        if sentiment is not None:
             #loss = results.loss
-            loss = self._loss(logits, label.long().view(-1))
+            loss = self._loss(logits, sentiment.long().view(-1))
             output_dict["loss"] = loss
-            self._accuracy(logits, label)
+            self._accuracy(logits, sentiment)
         return output_dict
 
 

--- a/modules/readers/StanceDataReader.py
+++ b/modules/readers/StanceDataReader.py
@@ -1,0 +1,162 @@
+import json
+import random
+from io import BytesIO
+from typing import Dict, List, Optional
+import logging
+from zipfile import ZipFile
+
+import torch
+from allennlp.data.tokenizers.tokenizer import Tokenizer
+from overrides import overrides
+
+from allennlp.common.file_utils import cached_path
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.fields import TextField, SequenceLabelField, MetadataField, Field, LabelField
+from allennlp.data.instance import Instance
+from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
+from allennlp.data.tokenizers import Token
+from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WORD_TAG_DELIMITER = "###"
+
+
+@DatasetReader.register("stance_data_reader")
+class StanceDataReader(DatasetReader):
+    """
+
+
+    # Parameters
+
+    word_tag_delimiter: `str`, optional (default=`"###"`)
+        The text that separates each WORD from its TAG.
+    token_delimiter: `str`, optional (default=`None`)
+        The text that separates each WORD-TAG pair from the next pair. If `None`
+        then the line will just be split on whitespace.
+    token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
+        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        Note that the `output` tags will always correspond to single token IDs based on how they
+        are pre-tokenised in the data file.
+    """
+
+    def __init__(
+        self,
+        word_tag_delimiter: str = DEFAULT_WORD_TAG_DELIMITER,
+        token_delimiter: str = None,
+        token_indexers: Dict[str, TokenIndexer] = None,
+        tokenizer: Optional[Tokenizer] = None,
+        task: int = 1,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
+        )
+        self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._word_tag_delimiter = word_tag_delimiter
+        self._token_delimiter = token_delimiter
+        self._tokenizer = tokenizer
+        self._task = task
+    @overrides
+    def _read(self, file_path):
+        # if `file_path` is a URL, redirect to the cache
+        file_path, split = file_path.split('@')
+        if split=='pred':
+            with open(file_path, 'r') as myfile:
+                for line in myfile.readlines():
+                    line = line.strip('\n')
+                    if not line:
+                        continue
+                    sentence, target, sentiment = line.split('###')
+                    yield self.text_to_instance(sentence=sentence, target=target, sentiment=sentiment)
+        else:
+            data = self.get_dataset()
+            sent_tag = self.get_tags(data)
+            random.seed(5)
+            random.shuffle(sent_tag['test'])
+            sent_tag['val'] = []
+            for i in range(300):
+                sent_tag['val'].append(sent_tag['test'].pop())
+            for sentence, target, sentiment, tags in self.shard_iterable(sent_tag[split]):
+                if self._task == 1:
+                    tags = [str(int(tag)) for tag in tags]
+                    yield self.text_to_instance(sentence=sentence, tags=tags, sentiment=sentiment)
+                elif self._task == 2:
+                    yield self.text_to_instance(sentence=sentence, target=target, sentiment=sentiment)
+                elif self._task == 3:
+                    pass
+                else:
+                    pass
+
+    def text_to_instance(  # type: ignore
+        self, sentence: str, target: str = None, tags: List[str] = None, sentiment: int = None
+    ) -> Instance:
+        """
+        We take `pre-tokenized` input here, because we don't have a tokenizer in this class.
+        """
+
+        fields: Dict[str, Field] = {}
+        if self._task == 1:
+            tokens = [Token(word) for word in sentence.split()]
+        if self._task == 2:
+            sentence = '[CLS] ' + sentence + ' [SEP] ' + target + ' [SEP]'
+            tokens = self._tokenizer.tokenize(sentence)
+        sequence = TextField(tokens)
+        fields["tokens"] = sequence
+        fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
+        if tags is not None:
+            fields["tags"] = SequenceLabelField(tags, sequence)
+        if sentiment is not None:
+            sentiment = str(sentiment) #'0' if str(sentiment) == '-1' else '1'
+            fields["sentiment"] = LabelField(sentiment)
+        return Instance(fields)
+
+    @overrides
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["tokens"]._token_indexers = self._token_indexers  # type: ignore
+
+    def get_tags(self, data):
+        sent_tag = {'train': [], 'val': [], 'test': []}
+        for split, dataset in data.items():
+            for sentence, target, sentiment in dataset:
+                tag = torch.zeros(len(sentence.split()))
+                target_len = len(target.split())
+                temp_target = target.replace(' ', '')
+                temp_sentence = sentence.replace(target, temp_target)
+                sent_list = temp_sentence.split()
+                if temp_target in sent_list:
+                    start_index = sent_list.index(temp_target)
+                else:
+                    continue
+                end_index = start_index + target_len
+                for i in range(start_index, end_index):
+                    tag[i] = 1
+                sent_tag[split].append((sentence, target, sentiment, tag))
+        return sent_tag
+
+    def get_dataset(self):
+        logger.log(level=20, msg="Data is being downloaded ...")
+        resp = urlopen("https://research.ibm.com/haifa/dept/vst/files/IBM_Debater_(R)_CS_EACL-2017.v1.zip")
+        zipfile = ZipFile(BytesIO(resp.read()))
+        file = 'IBM_Debater_(R)_CS_EACL-2017.v1/claim_stance_dataset_v1.json'
+
+        with zipfile.open(file, 'r') as myfile:
+            logger.info("Reading instances from lines in file at: %s", file)
+            data = myfile.read()
+        zipfile.close()
+        myfile.close()
+        obj = json.loads(data)
+        data = {'train': [], 'test': []}
+        for topic in obj:
+            split = topic['split']
+
+            if 'topicTarget' in topic:
+                data[split].append((topic['topicText'], topic['topicTarget'], topic['topicSentiment']))
+            for claim in topic['claims']:
+                if claim['Compatible'] == 'no' or claim['claimSentiment'] is None or claim['claimTarget'][
+                    'text'] is None:
+                    continue
+                data[split].append((claim['claimCorrectedText'], claim['claimTarget']['text'],
+                                    claim['claimSentiment']))
+
+        return data

--- a/modules/readers/__init__.py
+++ b/modules/readers/__init__.py
@@ -1,2 +1,1 @@
-#import modules.readers.SentDataReader
-from modules.readers.SentDataReader import SentimentDatasetReader2
+from modules.readers.StanceDataReader import StanceDataReader

--- a/modules/tools/__init__.py
+++ b/modules/tools/__init__.py
@@ -1,0 +1,1 @@
+from modules.tools.wandb_callback import CustomWandBCallback


### PR DESCRIPTION
Following changes are made:
1. There is no need to run `create_dataset.py` script to create data. A common dataset reader called `StanceDatasetReader` is added which automatically downloads data and returns instance based on the parameter `task`. This parameter is provided to dataset reader constructor either via config file or by overrides. Currently, `task=1` means claim target identification and `task=2` means claim sentiment classification.
2. Above change helps in using allennlp `predict` command that predicts output for given task and store it in a text file.
3. Since we do not require local data file to read data, we use `_@SPLIT` format wherever data path is required. For example in config, we specify `train_path` as` _@train`. Similarly while evaluating we specify test path in command as `_@test`. There is one exception to this, whenever we want to evaluate using predicted values for instance if we want to evaluate sentiment classification model on predictions done by claim target identification task then we provide test path in evaluate command as `PATH/TO/PREDICTION@pred`. Notice we distinguish this case using `pred` instead of test, train or val.