### PR TITLE
Stance Classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,17 @@ experiment/train/sentiment/absa \
 _@test
 ```
 
+### Stance Classification
+This will calculate the accuracy of our stance classification model. It requires 
+two prediction files. First we predict the claim targets and then using the predicted 
+claim target, we predict sentiment towards target (review_prediction_from_pred.txt)
+finally, we used the predicted target to predict relation
+(prediction_from_review_pred.txt) with topic target.
+
+```
+python stance_classifier.py \
+--pred_rel_file \
+experiment/prediction/contrast/prediction_from_review_pred.txt \
+--pred_sent_file \
+experiment/prediction/sentiment/review_prediction_from_pred.txt
+```

--- a/modules/readers/StanceDataReader.py
+++ b/modules/readers/StanceDataReader.py
@@ -199,7 +199,8 @@ class StanceDataReader(DatasetReader):
                                                   'claimSentiment': claim['claimSentiment'],
                                                   'claimCorrectedText': self.remove_punctuation(
                                                       claim['claimCorrectedText']),
-                                                  'topic_id': id}
+                                                  'topic_id': id,
+                                                  'stance':claim['stance']}
                                                  )
                 else:
                     data[split]['claims'].append({'claimTarget': self.remove_punctuation(claim['claimTarget']['text']),
@@ -207,7 +208,8 @@ class StanceDataReader(DatasetReader):
                                                   'claimSentiment': claim['claimSentiment'],
                                                   'claimCorrectedText': self.remove_punctuation(
                                                       claim['claimCorrectedText']),
-                                                  'topic_id': id}
+                                                  'topic_id': id,
+                                                  'stance':claim['stance']}
                                                  )
 
         return data

--- a/modules/readers/StanceDataReader.py
+++ b/modules/readers/StanceDataReader.py
@@ -47,6 +47,7 @@ class StanceDataReader(DatasetReader):
             token_indexers: Dict[str, TokenIndexer] = None,
             tokenizer: Optional[Tokenizer] = None,
             task: int = 1,
+            val: bool = True,
             **kwargs,
     ) -> None:
         super().__init__(
@@ -57,6 +58,7 @@ class StanceDataReader(DatasetReader):
         self._token_delimiter = token_delimiter
         self._tokenizer = tokenizer
         self._task = task
+        self.val = val
 
     @overrides
     def _read(self, file_path):
@@ -191,7 +193,7 @@ class StanceDataReader(DatasetReader):
                 if claim['Compatible'] == 'no' or claim['claimSentiment'] is None or claim['claimTarget'][
                     'text'] is None:
                     continue
-                if split == 'test' and i % 4 == 0:
+                if split == 'test' and i % 4 == 0 and self.val:
                     data['val']['claims'].append({'claimTarget': self.remove_punctuation(claim['claimTarget']['text']),
                                                   'targetsRelation': claim['targetsRelation'],
                                                   'claimSentiment': claim['claimSentiment'],

--- a/stance_classifier.py
+++ b/stance_classifier.py
@@ -1,0 +1,47 @@
+import json
+import sys
+
+import argparse
+
+def get_predictions(pred_file: str):
+    with open(pred_file, 'r') as myfile:
+        data = myfile.read()
+    myfile.close()
+    return json.loads(data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Arguments to classify stance')
+
+    parser.add_argument(
+        '--pred_rel_file',
+        help='Prediction file with predicted relation',
+        type=str, required=False
+    )
+
+    parser.add_argument(
+        '--pred_sent_file',
+        help='Prediction file with predicted sentiment',
+        type=str, required=False
+    )
+
+    args, remaining_args = parser.parse_known_args()
+
+    rel_data = get_predictions(args.pred_rel_file)
+    sent_data = get_predictions(args.pred_sent_file)
+    topics = {}
+    correct = 0
+    for k, v in sent_data.items():
+        if v['true']['topic']:
+            topics[v['true']['topic_id']] = v['true']['topicSentiment']
+    for k, v in rel_data.items():
+        if not v['true']['topic']:
+            claim_sentiment = int(v['true']['predictedClaimSentiment'])
+            target_sentiment = int(topics[v['true']['topic_id']])
+            relation = int(v['predictions']['predictedRelation'])
+            stance = claim_sentiment * target_sentiment * relation
+
+            if (stance == 1 and v['true']['stance'] == 'PRO') or (stance == -1 and v['true']['stance'] == 'CON'):
+                correct += 1
+    total = len(rel_data.keys())
+    print(f'Accuracy: {correct*100/total}')


### PR DESCRIPTION
Following updates are done:
1. `read()` method is optimised by removing redundant code. We create instances based on type of task and this check is done in `read()` method now.
2. `text_to_instance()` method is optimised and generalised. There are no unnecessary parameters given to `text_to_instance()` method. It takes a tuple named `sentences`, `label` which can be list of tags (for task 1), sentiment or relation and rest of information regarding claim and topic is sent in a dictionary as `metadata`.
3. tags are now created for both topics and claims separately and saved as `t_tags` and `c_tags` respectively. We call get_tags() method inside get_data() method now.
4. stance_classifier.py is added. This will calculate the accuracy of our stance classification model. It requires two prediction files. First we predict the claim targets and then using the predicted claim target, we predict sentiment towards target finally, we used the predicted target to predict relation with topic target.